### PR TITLE
get the sensor for your own purposes

### DIFF
--- a/src/ofxKinectCommonBridge.cpp
+++ b/src/ofxKinectCommonBridge.cpp
@@ -469,13 +469,7 @@ bool ofxKinectCommonBridge::initDepthStream( int width, int height, bool nearMod
 
 	if (mappingDepthToColor)
 	{
-		// get the port ID from the simple api
-		const WCHAR* wcPortID = KinectGetPortID(hKinect);
-
-		// create an instance of the same sensor
-		INuiSensor* nuiSensor = nullptr;
-		HRESULT hr = NuiCreateSensorById(wcPortID, &nuiSensor);
-		nuiSensor->NuiGetCoordinateMapper(&mapper);
+		this->getNuiSensor().NuiGetCoordinateMapper(&mapper);
 	}
 
 	if(bStarted){
@@ -704,6 +698,22 @@ bool ofxKinectCommonBridge::start()
 	startThread(true, false);
 	bStarted = true;	
 	return true;
+}
+
+//----------------------------------------------------------
+KCBHANDLE ofxKinectCommonBridge::getHandle() {
+	return this->hKinect;
+}
+
+//----------------------------------------------------------
+INuiSensor & ofxKinectCommonBridge::getNuiSensor() {
+	// get the port ID from the simple api
+	const WCHAR* wcPortID = KinectGetPortID(hKinect);
+
+	// create an instance of the same sensor
+	INuiSensor* nuiSensor = nullptr;
+	HRESULT hr = NuiCreateSensorById(wcPortID, &nuiSensor);
+	return * nuiSensor;
 }
 
 //----------------------------------------------------------

--- a/src/ofxKinectCommonBridge.h
+++ b/src/ofxKinectCommonBridge.h
@@ -56,6 +56,8 @@ class ofxKinectCommonBridge : protected ofThread {
 	bool initIRStream( int width, int height );
 	bool initSkeletonStream( bool seated );
 	bool start();
+	KCBHANDLE getHandle();
+	INuiSensor & getNuiSensor();
 
 	void stop();
 


### PR DESCRIPTION
heya! 
this is a feature so that people can get KinectSDK sensor and KinectCommonBridge handle to do all the usual things

i think it might be best to cache the sensor at initialisation rather than have it in the getSensor command
just curious if you guys see any issue with this?
