### PR TITLE
populate and store new NUI_DEPTH_IMAGE_PIXEL* array

### DIFF
--- a/src/ofxKinectCommonBridge.h
+++ b/src/ofxKinectCommonBridge.h
@@ -154,6 +154,7 @@ class ofxKinectCommonBridge : protected ofThread {
 	ofPixels& getColorPixelsRef();
 	ofPixels & getDepthPixelsRef();       	///< grayscale values
 	ofShortPixels & getRawDepthPixelsRef();	///< raw 11 bit values
+	NUI_DEPTH_IMAGE_PIXEL* getNuiDepthPixelsRef();
 
 	/// enable/disable frame loading into textures on update()
 	void setUseTexture(bool bUse);
@@ -246,6 +247,7 @@ class ofxKinectCommonBridge : protected ofThread {
 	ofPixels depthPixelsBack;
 	ofShortPixels depthPixelsRaw;
 	ofShortPixels depthPixelsRawBack;	///< depth back
+	NUI_DEPTH_IMAGE_PIXEL* depthPixelsNui;
 
 	ofPixels irPixels;
 	ofPixels irPixelsBack;


### PR DESCRIPTION
I've replaced the temporary NUI_DEPTH_IMAGE_PIXEL\* array you were using in mappingDepthToColor with a permanent one stored in the class so that this array can be accessed publicly. I did this from a need to get to the playerIndex, and to use this array for the INuiFusionReconstruction::DepthToDepthFloatFrame method I'm using to integrate Kinect Fusion.

This is not really ideal - instead I think we would properly integrate Kinect Fusion as you're doing with Face Tracking and Voice Recognition, but having access to this array in its original form is helpful in the meantime.
